### PR TITLE
Fix issues when used within ember-engines.

### DIFF
--- a/app/components/-dynamic-element-alt.js
+++ b/app/components/-dynamic-element-alt.js
@@ -1,1 +1,10 @@
-export { default } from '@ember/component';
+import Component from '@ember/component';
+
+// avoiding reexport directly here because in some circumstances (ember-engines
+// for example) a simple reexport is transformed to `define.alias`,
+// unfortunately at the moment (ember-source@3.13) there is no _actual_
+// `@ember/component` module to alias so this causes issues
+//
+// tldr; we can replace this with a simple reexport when we can rely on Ember
+// actually providing a `@ember/component` module
+export default Component.extend();

--- a/app/components/-dynamic-element.js
+++ b/app/components/-dynamic-element.js
@@ -1,1 +1,10 @@
-export { default } from '@ember/component';
+import Component from '@ember/component';
+
+// avoiding reexport directly here because in some circumstances (ember-engines
+// for example) a simple reexport is transformed to `define.alias`,
+// unfortunately at the moment (ember-source@3.13) there is no _actual_
+// `@ember/component` module to alias so this causes issues
+//
+// tldr; we can replace this with a simple reexport when we can rely on Ember
+// actually providing a `@ember/component` module
+export default Component.extend();


### PR DESCRIPTION
Avoiding reexport directly here because in some circumstances (ember-engines for example) a simple reexport is transformed to `define.alias`, unfortunately at the moment (ember-source@3.13) there is no _actual_ `@ember/component` module to alias so this causes issues

tldr; we can replace this with a simple reexport when we can rely on Ember actually providing a `@ember/component` module

Fixes #7
Fixes https://github.com/ember-engines/ember-engines/issues/676