### PR TITLE
Allowing passing `{{element}}` as arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Installation
 ember install ember-element-helper
 ```
 
-
 Usage
 ------------------------------------------------------------------------------
 
@@ -32,6 +31,23 @@ Usage
 {{#let (element this.tagName) as |Tag|}}
   <Tag class="my-tag">hello world!</Tag>
 {{/let}}
+```
+
+You can also pass around the result of invoking this helper into any components
+that accepts "contextual components" as arguments:
+
+```hbs
+<MyComponent @tag={{element "span"}} />
+```
+
+```hbs
+{{!-- in my-component.hbs --}}
+{{#let @tag as |Tag|}}
+  <Tag class="my-tag">hello world!</Tag>
+{{/let}}
+
+{{!-- ...or more directly... --}}
+<@tag class="my-tag">hello world!</@tag>
 ```
 
 Contributing

--- a/lib/element-helper-syntax-plugin.js
+++ b/lib/element-helper-syntax-plugin.js
@@ -31,43 +31,45 @@ module.exports = class ElementHelperSyntaxPlugin {
 
       MustacheStatement(node) {
         if (isElementHelper(node, locals)) {
-          throw error('cannot be appended to the DOM directly', node);
+          let { path, params, hash } = transformParts(node, b);
+          return b.mustache(path, params, hash, false, node.loc);
         }
       },
 
       SubExpression(node) {
-        // ignore locals for sub-expression posistions for now
-        // https://github.com/emberjs/ember.js/issues/17121#issuecomment-430369495
-        if (isElementHelper(node, [])) {
-          validateElementHelperArgs(node);
-
-          return b.sexpr(
-            // path
-            b.path('component', node.path.loc),
-            // params
-            [b.sexpr(
-              // path
-              b.path('-element', node.path.loc),
-              // params
-              node.params,
-              // hash
-              node.hash,
-              // loc
-              node.loc
-            )],
-            // hash
-            b.hash([
-              b.pair('tagName', node.params[0], node.params[0].loc)
-            ], node.params[0].loc),
-            // loc
-            node.loc
-          );
+        if (isElementHelper(node, locals)) {
+          let { path, params, hash } = transformParts(node, b);
+          return b.sexpr(path, params, hash, node.loc);
         }
       }
     });
 
     return ast;
   }
+}
+
+function transformParts(node, b) {
+  validateElementHelperArgs(node);
+
+  return {
+    // path
+    path: b.path('component', node.path.loc),
+    // params
+    params: [b.sexpr(
+      // path
+      b.path('-element', node.path.loc),
+      // params
+      node.params,
+      // hash
+      node.hash,
+      // loc
+      node.loc
+    )],
+    // hash
+    hash: b.hash([
+      b.pair('tagName', node.params[0], node.params[0].loc)
+    ], node.params[0].loc)
+  };
 }
 
 function hasLocalVariable(name, locals) {

--- a/node-tests/syntax-errors-test.js
+++ b/node-tests/syntax-errors-test.js
@@ -51,12 +51,4 @@ QUnit.module('element helper: syntax errors', () => {
       new Error('the `element` helper does not take a block (on line 2 column 8)')
     );
   });
-
-  test('it cannot be used in a mustache position', assert => {
-    assert.throws(() => precompile(`
-        {{element "h1"}}
-      `),
-      new Error('the `element` helper cannot be appended to the DOM directly (on line 2 column 8)')
-    );
-  });
 });

--- a/tests/dummy/app/components/element-receiver.js
+++ b/tests/dummy/app/components/element-receiver.js
@@ -1,0 +1,5 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  tagName: ''
+});

--- a/tests/dummy/app/templates/components/element-receiver.hbs
+++ b/tests/dummy/app/templates/components/element-receiver.hbs
@@ -1,0 +1,1 @@
+<@tag id="content">{{yield}}</@tag>

--- a/tests/integration/helpers/element-test.js
+++ b/tests/integration/helpers/element-test.js
@@ -163,7 +163,7 @@ module('Integration | Helper | element', function(hooks) {
     this.set('tagName', 'h1');
 
     await render(hbs`
-      {{#let (element tagName) as |Tag|}}
+      {{#let (element this.tagName) as |Tag|}}
         <Tag id="content">rendered {{counter}} time(s)</Tag>
       {{/let}}
     `);
@@ -213,5 +213,55 @@ module('Integration | Helper | element', function(hooks) {
     assert.dom('h1#content').hasText('rendered 5 time(s)');
     assert.dom('h2#content').doesNotExist();
     assert.dom('h3#content').doesNotExist();
+  });
+
+  test('it can be passed as argument', async function(assert) {
+    this.set('tagName', 'p');
+
+    await render(hbs`<ElementReceiver @tag={{element this.tagName}}>Test</ElementReceiver>`);
+
+    assert.dom('p#content').hasText('Test');
+
+    this.set('tagName', 'div');
+
+    await settled();
+
+    assert.dom('div#content').hasText('Test');
+
+    this.set('tagName', '');
+
+    await settled();
+
+    assert.equal(this.element.innerHTML.trim(), 'Test');
+
+    this.set('tagName', 'p');
+
+    await settled();
+
+    assert.dom('p#content').hasText('Test');
+  });
+
+  test('it can be invoked inline', async function(assert) {
+    this.set('tagName', 'p');
+
+    await render(hbs`{{element this.tagName}}`);
+
+    assert.dom('p').exists();
+
+    this.set('tagName', 'br');
+
+    await settled();
+
+    assert.dom('br').exists();
+
+    this.set('tagName', '');
+
+    assert.equal(this.element.innerHTML.trim(), '<!---->');
+
+    this.set('tagName', 'p');
+
+    await settled();
+
+    assert.dom('p').exists();
   });
 });


### PR DESCRIPTION
This is a squashed/rebased version of #19. Most of the upgrades were moved to #20 and I don't think we are ready to take on TypeScript support so reverted that as well.

This enables using the `{{element}}` helper in mustache positions, allowing it to be passed as angle bracket arguments or appended to the DOM in content positions.

This matches the proposed semantics in the RFC.

Closes #18, #19