### PR TITLE
Support Parallel Build

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,14 +4,22 @@ module.exports = {
   name: require('./package').name,
 
   setupPreprocessorRegistry(_type, registry) {
-    registry.add('htmlbars-ast-plugin', {
+    let pluginObj  = this._buildPlugin();
+    pluginObj.parallelBabel = {
+      requireFile: __filename,
+      buildUsing: '_buildPlugin',
+      params: {},
+    };
+    registry.add('htmlbars-ast-plugin', pluginObj);
+  },
+
+  _buildPlugin() {
+    return {
       name: 'element-helper-syntax',
-
       plugin: require('./lib/element-helper-syntax-plugin'),
-
       baseDir: function() {
         return __dirname;
       }
-    });
+    };
   }
 };


### PR DESCRIPTION
**Issues**
Observe issues while trying to include addon in my project
```
[broccoli-persistent-filter:Babel > [Babel: ember-element-helper]: Babel: ember-element-helper] was configured to `throwUnlessParallelizable` and was unable to parallelize a plugin. 
plugins:
1: name: unknown, location: unknown
```

Update to support parallel build