### PR TITLE
Migrate to functional plugin format.

### DIFF
--- a/lib/element-helper-syntax-plugin.js
+++ b/lib/element-helper-syntax-plugin.js
@@ -1,9 +1,10 @@
-module.exports = class ElementHelperSyntaxPlugin {
-  transform(ast) {
-    let b = this.syntax.builders;
-    let locals = [];
+module.exports = (env) => {
+  let b = env.syntax.builders;
+  let locals = [];
 
-    this.syntax.traverse(ast, {
+  return {
+    name: 'ember-element-helper',
+    visitor: {
       BlockStatement: {
         enter(node) {
           locals.push(node.program.blockParams);
@@ -37,11 +38,9 @@ module.exports = class ElementHelperSyntaxPlugin {
           return b.sexpr(path, params, hash, node.loc);
         }
       }
-    });
-
-    return ast;
+    }
   }
-}
+};
 
 function transformParts(node, b) {
   return {


### PR DESCRIPTION
Ember has internally migrated from the class based plugin format into this functional one for quite a while, but has finally deprecated the class based version.

This updates the transform to use the newer style and avoid the deprecation.

References:

* https://github.com/emberjs/ember.js/pull/19429
