### PR TITLE
Updated the URL for Build status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ember-element-helper
 ==============================================================================
 
-[![Build Status](https://github.com/tildeio/ember-element-helper/workflows/Build/badge.svg?branch=master)](https://github.com/tildeio/ember-element-helper/actions?query=branch%3Amaster+workflow%3A%22Build%22)
+[![Build Status](https://github.com/tildeio/ember-element-helper/actions/workflows/build.yml/badge.svg)](https://github.com/tildeio/ember-element-helper/actions/workflows/build.yml)
 
 Dynamic element helper for Glimmer templates.
 


### PR DESCRIPTION
## Description

Hello. I noticed that the Build badge shows a failing status, even though the [Actions tab](https://github.com/tildeio/ember-element-helper/actions/workflows/build.yml) shows that the scheduled builds have been passing.

<img width="800" alt="The Build status badge currently shows failing" src="https://user-images.githubusercontent.com/16869656/115707712-6b30f500-a36f-11eb-8cf1-bada1fc73d24.png">

I think the badge status is incorrect because the default branch name had been changed to `main` but the URL had not.