### PR TITLE
Add baseDir to babel plugin to enable caching

### DIFF
--- a/lib/element-helper-syntax-plugin.js
+++ b/lib/element-helper-syntax-plugin.js
@@ -1,4 +1,4 @@
-module.exports = (env) => {
+function elementHelperSyntaxPlugin(env) {
   let b = env.syntax.builders;
   let locals = [];
 
@@ -40,7 +40,11 @@ module.exports = (env) => {
       }
     }
   }
-};
+}
+
+elementHelperSyntaxPlugin.baseDir = function() { return __dirname; };
+
+module.exports = elementHelperSyntaxPlugin;
 
 function transformParts(node, b) {
   return {


### PR DESCRIPTION
The build under embroider complained that this plugin prevented proper caching. I've tried it in our app and defining the `baseDir` made the warning go away.

Fixes https://github.com/tildeio/ember-element-helper/issues/53