### PR TITLE
Fix publishing automation

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,9 @@
       "release": true,
       "tokenRef": "GITHUB_AUTH"
     },
-    "npm": false
+    "npm": {
+      "publish": false
+    }
   },
   "volta": {
     "node": "10.20.1",


### PR DESCRIPTION
The prior changes disabled `npm` all together, but unfortunately that
means it also won't bump the version in package.json.

This brings back the `npm` task for bumping, but disables `npm publish`.

See docs https://github.com/release-it/release-it/blob/HEAD/docs/npm.md#skip-publish
