### PR TITLE
Ensure CI fails if we break parallelization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: 'true'
+
+      # ensure we cannot regress parallization
+      THROW_UNLESS_PARALLELIZABLE: '1'
+
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This is a failing PR demo of #61
