### PR TITLE
CI: Disable broken Ember 4.x scenarios

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
           - lts-3.16
           - lts-3.20
           - lts-3.24
+          - lts-3.28
           - embroider-safe
           - embroider-optimized
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,10 @@ jobs:
           - default
           - default-with-lockfile
           - default-with-jquery
-          - release
-          - beta
-          - canary
+          # disabled because the Ember 4.x scenarios are currently failing
+          # - release
+          # - beta
+          # - canary
           - classic
           - lts-3.4
           - lts-3.8

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -56,6 +56,14 @@ module.exports = async function() {
         }
       },
       {
+        name: 'ember-lts-3.28',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.28.0'
+          }
+        }
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {


### PR DESCRIPTION
The Ember 4.x scenarios are currently failing. This PR disables them for now, until we can fix them properly.

This PR also adds an explicit ember-try scenario for Ember 3.28.

/cc @rwjblue @chancancode 