### PR TITLE
Support ember-source > v4

### DIFF
--- a/ember-element-helper/package.json
+++ b/ember-element-helper/package.json
@@ -81,7 +81,7 @@
     "extends": "../package.json"
   },
   "peerDependencies": {
-    "ember-source": "^3.8 || 4"
+    "ember-source": "^3.8 || >= 4.0.0"
   },
   "release-it": {
     "plugins": {


### PR DESCRIPTION
In strict environments, we need peer declarations to be correct, otherwise folks can used ember-source > v4