### PR TITLE
Remove reference to EmberComponent to remove the triple-slash directive

### DIFF
--- a/ember-element-helper/src/helpers/element.ts
+++ b/ember-element-helper/src/helpers/element.ts
@@ -5,6 +5,8 @@ import { assert, runInDebug } from '@ember/debug';
 
 import { ensureSafeComponent } from '@embroider/util';
 
+import type { ComponentLike } from '@glint/template';
+
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 function UNINITIALIZED() {}
 
@@ -13,7 +15,7 @@ export type ElementFromTagName<T extends string> = T extends keyof HTMLElementTa
   : Element;
 
 type Positional<T extends string> = [name: T];
-type Return<T extends string> = typeof EmberComponent<{
+type Return<T extends string> = ComponentLike<{
   Element: ElementFromTagName<T>;
   Blocks: { default: [] };
 }>;


### PR DESCRIPTION
Resolves: https://github.com/tildeio/ember-element-helper/issues/111

This removes the 
```
/// <reference types="ember-source/types/preview/@ember/object/core" />
/// <reference types="ember-source/types/preview/@ember/object/mixin" />
```
that is present in this version: https://www.npmjs.com/package/ember-element-helper/v/0.8.2?activeTab=code

explanation of the problem:
- https://github.com/tracked-tools/ember-async-data/pull/704