### PR TITLE
Add typesVersions to package.json to make TS imports work

### DIFF
--- a/ember-element-helper/package.json
+++ b/ember-element-helper/package.json
@@ -21,6 +21,13 @@
     },
     "./addon-main.js": "./addon-main.cjs"
   },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "declarations/*"
+      ]
+    }
+  },
   "files": [
     "dist",
     "declarations",


### PR DESCRIPTION
without this fix, in https://github.com/ember-animation/ember-animated/pull/613 I have following error

```
[types] src/components/animated-container.ts:6:41 - error TS2307: Cannot find module 'ember-element-helper' or its corresponding type declarations.
[types] 
[types] 6 import type { ElementFromTagName } from 'ember-element-helper';
[types]                                           ~~~~~~~~~~~~~~~~~~~~~~
[types] 
[types] src/template-registry.ts:5:47 - error TS2307: Cannot find module 'ember-element-helper' or its corresponding type declarations.
[types] 
[types] 5 import type { element as ElementHelper } from 'ember-element-helper';
[types]                                                 ~~~~~~~~~~~~~~~~~~~~~~
```